### PR TITLE
Benf/bugfix/sim iris uplink fix

### DIFF
--- a/IRIS/iris_simulated_client.py
+++ b/IRIS/iris_simulated_client.py
@@ -30,7 +30,7 @@ import socket
 import sys
 
 DEFAULT_HOST = '127.0.0.1'
-DEFAULT_PORT = 1821
+DEFAULT_PORT = 1806
 MAX_RECEIVE = 1024
 FLAG_HEADER = 'FLAG'
 END_FLAG = "|END" # END_FLAG should have same length as FLAGSIZE

--- a/IRIS/iris_simulated_server.py
+++ b/IRIS/iris_simulated_server.py
@@ -18,7 +18,7 @@ import queue
 import iris_subsystem
 
 DEFAULT_HOST = '127.0.0.1'
-DEFAULT_PORT = 1821
+DEFAULT_PORT = 1806
 MAX_COMMANDSIZE = 128
 END_FLAG = "|END|"
 
@@ -94,10 +94,12 @@ def output_send(conn, reply_buffer):
                         element = element.encode()
                     conn.sendall(header.encode())
                     conn.sendall(element)
+                    logging.info("Sent: %s\n", element)
             else:
                 header = "FLAG:" + str(len(reply)) + ':'
                 conn.sendall(header.encode())
                 conn.sendall(reply.encode())
+                logging.info("Sent: %s\n", reply)
             conn.sendall(END_FLAG.encode())
         except BrokenPipeError:
             logging.info("Connection to client lost: Force closing output loop")

--- a/IRIS/iris_subsystem.py
+++ b/IRIS/iris_subsystem.py
@@ -190,9 +190,9 @@ class IRISSubsystem: # pylint: disable=too-many-instance-attributes
         """Simulates fecthing the housekeeping data on the IRIS subsystem.
             Note that due to socket handling tuples must be converted into string pairs
         """
-        current_state = []
+        current_state = ""
         for pair in self.state.items():
-            current_state.append(str(pair[0]) + ": " + str(pair[1]) + " ")
+            current_state = current_state + str(pair[0]) + ": " + str(pair[1]) + "\n"
         return current_state
 
     def num_images(self):


### PR DESCRIPTION
Quick fixes to get the IRIS simulated subsystem working with the iris handler for the uplink software. Updated the default ports and made minor adjustments to housekeeping packets.
I intend to revamp the simulated system to not have so much complex threading as it is not needed now, but this PR is simply to get it working