### PR TITLE
Drake/bugfix/simulated uhf bug fix

### DIFF
--- a/UHF/simulated_uhf.py
+++ b/UHF/simulated_uhf.py
@@ -13,7 +13,7 @@ import select
 # import struct
 
 DEBUG = 1
-BUFF_SIZE = 4096  # This might be wrong
+BUFF_SIZE = 4096
 COMMS_SIDE_SERVER_PORT = 1805
 GS_SIDE_SERVER_PORT = 1808
 BEACON_RATE = 10 # Set beacon to be sent every 10 seconds

--- a/UHF/simulated_uhf.py
+++ b/UHF/simulated_uhf.py
@@ -156,17 +156,15 @@ def process_cmd(cmd):
 
         case 'SET_MODE':
             try:
-                print("this ran")
                 uhf_params['MODE'] = int(val)
                 ret = f"set UHF mode to: {val}"
 
             except ValueError as e:
-                print("This should run instead")
                 print(e)
                 ret = str(e)
 
         case 'GET_BEACON':
-            ret = {uhf_params['BEACON']}
+            ret = uhf_params['BEACON']
 
         case 'SET_BEACON':
             uhf_params['BEACON'] = val

--- a/UHF/test_sim_uhf.sh
+++ b/UHF/test_sim_uhf.sh
@@ -19,5 +19,5 @@ gnome-terminal --title="SIM_UHF" -- bash -c "echo 'Starting simulated UHF'; slee
 gnome-terminal --title="COMS_HANDLER" -- bash -c "echo 'Starting simulated coms handler'; sleep 0.5; python3 generic_client.py 1805; exec bash"
 
 # Spawn terminal for fake gs
-gnome-terminal --title="GS" -- bash -c "echo 'Starting simulated gs'; sleep 0.5; python3 generic_client.py 1235; exec bash"
+gnome-terminal --title="GS" -- bash -c "echo 'Starting simulated gs'; sleep 0.5; python3 generic_client.py 1808; exec bash"
 


### PR DESCRIPTION
test.sh:
Changed the port number when initializing generic client for groundstation.

simulated_uhf.py:
minor bug fix when returning data to UHF handler. Changed msg size from 128 bytes to 4KB. Implemented timer for beacon so it only sends every 10 seconds AFTER a message is sent to groundstation. This prevents slicing error when performing bulk msg handling. 