### PR TITLE
Added header message to beacon to prevent groundstation errors

### DIFF
--- a/UHF/simulated_uhf.py
+++ b/UHF/simulated_uhf.py
@@ -86,7 +86,7 @@ def beacon(client_key, server, lock):
                     msg_len = len(uhf_params['BEACON']) + 5 + 2
                     msg_len_bytes = msg_len.to_bytes(2, "little")
                     beacon_content = bytes(uhf_params['BEACON'], "utf-8")
-                    header_bytes = bytes([msg_type, msg_id, dest_id, source_id, opcode])
+                    header_bytes = bytes([MSG_TYPE, MSG_ID, DEST_ID, SOURCE_ID, OPCODE])
                     beacon_msg = header_bytes + msg_len_bytes + beacon_content
                     client_pointer[client_key].sendall(beacon_msg)
                     if DEBUG:

--- a/UHF/simulated_uhf.py
+++ b/UHF/simulated_uhf.py
@@ -41,11 +41,11 @@ uhf_params = {'BAUD_RATE': 9600, 'BEACON':'beacon', 'MODE': 0}
 DELIMITER = ':'
 
 # Beacon Header constants
-msg_type = 0x03 # no msg type for beacon, give it value 3 for now
-msg_id = 0x00
-dest_id = 0x07 # ground station destination id (7)
-source_id = 0x0B
-opcode = 0x00 # dummy opcode
+MSG_TYPE = 0x03 # no msg type for beacon, give it value 3 for now
+MSG_ID = 0x00
+DEST_ID = 0x07 # ground station destination id (7)
+SOURCE_ID = 0x0B
+OPCODE = 0x00 # dummy opcode
 
 
 def check_port(port):
@@ -83,7 +83,7 @@ def beacon(client_key, server, lock):
             try:
                 if current_time - beacon_timer["last_send"] > BEACON_RATE:
                     # 5 bytes for rest of header and 2 more for the length itself
-                    msg_len = len(uhf_params['BEACON']) + 5 + 2  
+                    msg_len = len(uhf_params['BEACON']) + 5 + 2
                     msg_len_bytes = msg_len.to_bytes(2, "little")
                     beacon_content = bytes(uhf_params['BEACON'], "utf-8")
                     header_bytes = bytes([msg_type, msg_id, dest_id, source_id, opcode])

--- a/UHF/simulated_uhf.py
+++ b/UHF/simulated_uhf.py
@@ -13,7 +13,7 @@ import select
 # import struct
 
 DEBUG = 1
-BUFF_SIZE = 128
+BUFF_SIZE = 4096
 COMMS_SIDE_SERVER_PORT = 1805
 GS_SIDE_SERVER_PORT = 1808
 BEACON_RATE = 10 # Set beacon to be sent every 10 seconds

--- a/UHF/simulated_uhf.py
+++ b/UHF/simulated_uhf.py
@@ -10,12 +10,12 @@ import socket
 import threading
 import time
 import select
-# import struct
 
 DEBUG = 1
 BUFF_SIZE = 4096
-COMMS_SIDE_SERVER_PORT = 1805
-GS_SIDE_SERVER_PORT = 1808
+SIM_ENDUROSAT_UART_PORT = 1805
+GS_BEACON_PORT = 1809
+SIM_ESAT_UHF_PORT = 1808
 BEACON_RATE = 10 # Set beacon to be sent every 10 seconds
 COMM_SERVER_HOSTNAME = '127.0.0.1'
 GS_SERVER_HOSTNAME = '127.0.0.1'
@@ -255,7 +255,7 @@ def send_msg(client_key, buffer, lock):
                     _, port = client_pointer[client_key].getsockname()
 
                     # Reset beacon timer if message is sent to GS
-                    if port == GS_SIDE_SERVER_PORT:
+                    if port == SIM_ESAT_UHF_PORT:
                         beacon_timer["last_send"] = time.time()
                     if DEBUG:
                         print("***** AFTER *****")
@@ -298,7 +298,7 @@ def receive_msg(client_key, server, buffer, lock):
                     _, port = client_pointer[client_key].getsockname()
 
                     # Primitive check to see if messages intent was to modify UHF params
-                    if port == COMMS_SIDE_SERVER_PORT and b"UHF:" in message:
+                    if port == SIM_ENDUROSAT_UART_PORT and b"UHF:" in message:
                         data = process_cmd(message.decode('utf-8'))
                         with lock:
                             if DEBUG:
@@ -336,8 +336,8 @@ def main():
         None
     """
 
-    comm_server = start_server(COMM_SERVER_HOSTNAME, COMMS_SIDE_SERVER_PORT)
-    gs_server = start_server(GS_SERVER_HOSTNAME, GS_SIDE_SERVER_PORT)
+    comm_server = start_server(COMM_SERVER_HOSTNAME, SIM_ENDUROSAT_UART_PORT)
+    gs_server = start_server(GS_SERVER_HOSTNAME, SIM_ESAT_UHF_PORT)
 
     client_lock = threading.Lock()
 


### PR DESCRIPTION
In the process of re-coding the UHF handler I noticed that the simulated UHF beaconing to the groundstation caused a panic to occur. The fix was found to be that the UHF beacon did not have a message header, which in turn caused weird indexing errors since the msg structure lib uses the msg len field to parse the message. This PR fixes the issue by adding header contents to the UHF beacon.