### PR TITLE
[WIP] Added separate command line args for satellite and groundstation side tcp servers

### DIFF
--- a/UHF/README.md
+++ b/UHF/README.md
@@ -148,10 +148,23 @@ UHF:SET_MODE:3
 
 ```
 
-## Handling Clients Across Threads
+## Using command line arguments for hostnames
+The simulated UHF includes functionality for the user to provide hostnames for both uhf servers. This is intended to be used when testing on hardware and you don't want
+one or more of the hostnames to be localhost. If no command line arguments are given, both server's hostnames default to 127.0.0.1.\
 
-During satellite operation we will have times where the UHF loses connection with the groundstation. Because of this the simulated UHF provides
-functionality to enable clients to disconnect and reconnect to the server at any time. But because the client socket objects are shared between
-multiple threads in the simulated UHF program, we use a mutable data structure in python to act like a pointer to the socket objects. In conjunction with using a lock we can share this dictionary accross threads, so when a client disconnects and the simulated UHF attempts to reconnect (using search_client function) the new client socket object created is shared across threads via the client_pointer dictionary.
+Usage:
 
-Note that when a client disconnects, the simulated UHF will essentially stop all threads and operations and wait for the client to reconnect.
+```
+python3 simulated_uhf.py
+# or
+python3 simulated_uhf.py <ground facing side hostname>
+# or
+python3 simulated_uhf.py <ground facing side hostname> <satellite facing hostname>
+```
+
+The ground station facing side is the hostname you are expecting to use when you connect via the groundstation client. For example if you have the flight software and simulated
+UHF running off a zybo and the groundstation is being run on your device, You would give the ground facing side the hostname of the zybo, and not supply a command line arg
+for the satellite facing hostname since it already defaults to local host (important because its being run on the same device as coms handler in this case). The satellite facing
+side hostname is the hostname the coms handler expects to connect to. Using these command line arguments the user can run the simulated satellite on the same device as the
+groundstation software with using hardware, the flight side with hardware, same device if no hardware is used, or a different device then the flight and groundstation software 
+altogether.

--- a/UHF/simulated_uhf.py
+++ b/UHF/simulated_uhf.py
@@ -340,6 +340,7 @@ def main():
         satellite_side_hostname = DEFAULT_SERVER_HOSTNAME
     elif arg_len == 2:
         ground_side_hostname = sys.argv[1]
+        satellite_side_hostname = DEFAULT_SERVER_HOSTNAME
     elif arg_len == 3:
         ground_side_hostname = sys.argv[1]
         satellite_side_hostname = sys.argv[2]

--- a/UHF/simulated_uhf.py
+++ b/UHF/simulated_uhf.py
@@ -327,21 +327,33 @@ def main():
     Returns:
         None
     """
-    hostname = ""
+    # ground side hostname is the hostname used for connecting to groundstation clients
+    # like the beacon client and uhf client (in cli_groundstation program)
+    #
+    # satellite side is used for the for the satellite software to connect to (coms handler)
+    ground_side_hostname = ""
+    satellite_side_hostname = ""
     arg_len = len(sys.argv)
 
     if arg_len == 1:
-        hostname = DEFAULT_SERVER_HOSTNAME
+        ground_side_hostname = DEFAULT_SERVER_HOSTNAME
+        satellite_side_hostname = DEFAULT_SERVER_HOSTNAME
     elif arg_len == 2:
-        hostname = sys.argv[1]
+        ground_side_hostname = sys.argv[1]
+    elif arg_len == 3:
+        ground_side_hostname = sys.argv[1]
+        satellite_side_hostname = sys.argv[2]
     else:
         print("Error: Incorrect cmd line arg usage.")
-        print("Usage: simulated_uhf.py <hostname> or simulated_uhf.py")
+        print("""Usage: python3 simulated_uhf.py\n
+                or python3 simulated_uhf.py <ground side hostname>
+                or python3 simulated_uhf.py <ground side hostname> <satellite side hostname>
+              """)
         return -1
 
-    esat_uart_server = start_server(hostname, SIM_ESAT_UART_PORT)
-    esat_uhf_server = start_server(hostname, SIM_ESAT_UHF_PORT)
-    esat_beacon_server = start_server(hostname, SIM_ESAT_BEACON_PORT)
+    esat_uart_server = start_server(satellite_side_hostname, SIM_ESAT_UART_PORT)
+    esat_uhf_server = start_server(ground_side_hostname, SIM_ESAT_UHF_PORT)
+    esat_beacon_server = start_server(ground_side_hostname, SIM_ESAT_BEACON_PORT)
 
     client_lock = threading.Lock()
 


### PR DESCRIPTION
I realized that I had introduced a minor bug in my previous pull request #77 that used command line arguments for the hostname. The given hostname was used for ALL tcp servers that the simulated uhf hosts. So if someone were to test with the sim uhf and flight software on a zybo and then run the groundstation on their device, the esat uart server would not give the local host which might cause problems with the coms handler connecting to it. Apparently some devices resolve their static IP to localhost, but to add a proper fix I there is now an additional command line arg for both the groundstation and satellite facing servers. Now we can test with the uhf on the same device as groundstation, or same device as flight software, or different device altogether. Of course if no command line args are given then both server hostnames are just localhost.

Still have to test it but I will do this tomorrow.