### PR TITLE
Added additional ON/OFF functionality for EPS and other subsystems

### DIFF
--- a/EPS/README.md
+++ b/EPS/README.md
@@ -45,6 +45,7 @@ Use these commands to retrieve the value of a parameter.
 - `Current` - Current in amps.
 - `BatteryState` - Current state of the battery.
 - `WatchdogResetTime` - Time remaining for the watchdog reset in hours.
+- `EPSState` - State of EPS (ON/OFF).
 
 ### 2. **Update Commands**
 Use these commands to modify the value of a parameter.
@@ -62,7 +63,6 @@ Use these commands to modify the value of a parameter.
 - `Temperature` - Current temperature in degrees Celsius.
 - `Voltage` - Current voltage in volts.
 - `Current` - Current in amps.
-- `BatteryState` - Current state of the battery.
 - `WatchdogResetTime` - Time remaining for the watchdog reset in hours.
 
 ### 3. **Execute Commands**
@@ -78,7 +78,7 @@ Resets the EPS subsystem to its default state.
    ```
 - **Expected Output**:
    ```
-   Command ResetDevice executed
+   Device reset to default state
    ```
 
 #### b. Reset All Subsystems
@@ -89,7 +89,7 @@ Resets all subsystems to their default state.
    ```
 - **Expected Output**:
    ```
-   Command ResetSubsystems executed
+   Subsystems reset to default state
    ```
 
 #### c. Turn On a Subsystem
@@ -121,7 +121,7 @@ Checks if the subsystem is ON or OFF.
    ```
 - **Expected Output**:
    ```
-   GPS is OFF
+   GPS is OFF/ON
    ```
 
 #### f. Turn On EPS

--- a/EPS/README.md
+++ b/EPS/README.md
@@ -110,6 +110,20 @@ Turns off a specific subsystem by name.
    GPS turned OFF
    ```
 
+#### e. Turn On EPS
+Turns on the EPS.
+- **Command**
+   ```bash
+   echo -n "execute:TurnOnEPS" | nc 127.0.0.1 1801
+   ```
+
+#### e. Turn Off EPS
+Turns off the EPS.
+- **Command**
+   ```bash
+   echo -n "execute:TurnOffEPS" | nc 127.0.0.1 1801
+   ```
+
 #### Supported Subsystems:
 - `ADCS`
 - `Deployables`

--- a/EPS/README.md
+++ b/EPS/README.md
@@ -1,0 +1,122 @@
+# Usage Instructions for EPS Subsystem
+
+## Overview
+The EPS subsystem communicates using TCP sockets. Commands are sent as strings to the socket server, which parses the input and performs actions accordingly. These commands fall into three categories:
+
+1. **Request** - Retrieve the current value of a parameter.
+2. **Update** - Modify a parameter's value.
+3. **Execute** - Perform an action, such as resetting the device.
+
+## Prerequisites
+1. **Python 3.x** installed on your system.
+2. **Netcat (nc)** or any TCP client to send commands to the server.
+3. Host IP (`127.0.0.1` by default) and port (`1801` by default).
+
+## Starting the EPS Subsystem
+1. Clone this repository and navigate to the directory containing `eps_subsystem.py`.
+2. Start the subsystem server by running:
+   ```bash
+   python eps_subsystem.py
+   ```
+   Optionally, specify a custom port:
+   ```bash
+   python eps_subsystem.py 1234
+   ```
+3. The server will now listen for incoming commands.
+
+## Sending Commands
+You can interact with the EPS subsystem by sending commands using `netcat` or any TCP client.
+
+### 1. **Request Commands**
+Use these commands to retrieve the value of a parameter.
+- **Syntax**: `request:<parameter_name>`
+- **Example**:
+   ```bash
+   echo -n "request:Voltage" | nc 127.0.0.1 1801
+   ```
+- **Expected Output**:
+   ```
+   Voltage:5.24
+   ```
+
+#### Valid Parameters for Request:
+- `Temperature` - Current temperature in degrees Celsius.
+- `Voltage` - Current voltage in volts.
+- `Current` - Current in amps.
+- `BatteryState` - Current state of the battery.
+- `WatchdogResetTime` - Time remaining for the watchdog reset in hours.
+
+### 2. **Update Commands**
+Use these commands to modify the value of a parameter.
+- **Syntax**: `update:<parameter_name>:<new_value>`
+- **Example**:
+   ```bash
+   echo -n "update:WatchdogResetTime:48.0" | nc 127.0.0.1 1801
+   ```
+- **Expected Output**:
+   ```
+   Updated WatchdogResetTime to 48.0
+   ```
+
+#### Updatable Parameters:
+- `WatchdogResetTime` - Specify a new time (in hours) for the watchdog reset.
+
+### 3. **Execute Commands**
+Use these commands to perform predefined actions on the EPS subsystem.
+- **Syntax**: `execute:<command_name>`
+- **Examples**:
+
+#### a. Reset the Device
+Resets the EPS subsystem to its default state.
+- **Command**:
+   ```bash
+   echo -n "execute:ResetDevice" | nc 127.0.0.1 1801
+   ```
+- **Expected Output**:
+   ```
+   Command ResetDevice executed
+   ```
+
+#### b. Reset All Subsystems
+Resets all subsystems to their default state.
+- **Command**:
+   ```bash
+   echo -n "execute:ResetSubsystems" | nc 127.0.0.1 1801
+   ```
+- **Expected Output**:
+   ```
+   Command ResetSubsystems executed
+   ```
+
+#### c. Turn On a Subsystem
+Turns on a specific subsystem by name.
+- **Command**:
+   ```bash
+   echo -n "execute:SubsystemOn:GPS" | nc 127.0.0.1 1801
+   ```
+- **Expected Output**:
+   ```
+   GPS turned ON
+   ```
+
+#### d. Turn Off a Subsystem
+Turns off a specific subsystem by name.
+- **Command**:
+   ```bash
+   echo -n "execute:SubsystemOff:GPS" | nc 127.0.0.1 1801
+   ```
+- **Expected Output**:
+   ```
+   GPS turned OFF
+   ```
+
+#### Supported Subsystems:
+- `ADCS`
+- `Deployables`
+- `DFGM`
+- `GPS`
+- `IRIS`
+- `UHF`
+- `AntennaBurnWireGPIO`
+- `UHFBurnWireGPIO`
+

--- a/EPS/README.md
+++ b/EPS/README.md
@@ -16,11 +16,11 @@ The EPS subsystem communicates using TCP sockets. Commands are sent as strings t
 1. Clone this repository and navigate to the directory containing `eps_subsystem.py`.
 2. Start the subsystem server by running:
    ```bash
-   python eps_subsystem.py
+   python3 eps_subsystem.py
    ```
    Optionally, specify a custom port:
    ```bash
-   python eps_subsystem.py 1234
+   python3 eps_subsystem.py 1234
    ```
 3. The server will now listen for incoming commands.
 
@@ -59,7 +59,11 @@ Use these commands to modify the value of a parameter.
    ```
 
 #### Updatable Parameters:
-- `WatchdogResetTime` - Specify a new time (in hours) for the watchdog reset.
+- `Temperature` - Current temperature in degrees Celsius.
+- `Voltage` - Current voltage in volts.
+- `Current` - Current in amps.
+- `BatteryState` - Current state of the battery.
+- `WatchdogResetTime` - Time remaining for the watchdog reset in hours.
 
 ### 3. **Execute Commands**
 Use these commands to perform predefined actions on the EPS subsystem.
@@ -109,15 +113,25 @@ Turns off a specific subsystem by name.
    ```
    GPS turned OFF
    ```
+#### e. Check the state of a Subsystem
+Checks if the subsystem is ON or OFF.
+- **Command**:
+   ```bash
+   echo -n "execute:SubsystemState:GPS" | nc 127.0.0.1 1801
+   ```
+- **Expected Output**:
+   ```
+   GPS is OFF
+   ```
 
-#### e. Turn On EPS
+#### f. Turn On EPS
 Turns on the EPS.
 - **Command**
    ```bash
    echo -n "execute:TurnOnEPS" | nc 127.0.0.1 1801
    ```
 
-#### e. Turn Off EPS
+#### g. Turn Off EPS
 Turns off the EPS.
 - **Command**
    ```bash

--- a/EPS/eps_subsystem.py
+++ b/EPS/eps_subsystem.py
@@ -110,6 +110,6 @@ if __name__ == "__main__":
                 data = conn.recv(1024).decode().strip()
                 if not data:
                     break
-                response = eps.handle_command(data)
-                if response:
-                    conn.sendall((response+"\n").encode())
+                RESPONSE = eps.handle_command(data)
+                if RESPONSE:
+                    conn.sendall((RESPONSE+"\n").encode())

--- a/EPS/eps_subsystem.py
+++ b/EPS/eps_subsystem.py
@@ -108,11 +108,13 @@ class EPSSubsystem: #pylint:disable=too-few-public-methods disable=too-many-inst
         if self.eps_on is False:
             return "ERROR: EPS turned off. Please turn on EPS to execute command\n"
         self.set_state_dict(default_eps_state)
+        return "EPS returned to default state\n"
     def reset_subsystems_state(self):
         """Reset the subsystems to default state, which is defined at the top of this file."""
         if self.eps_on is False:
             return "ERROR: EPS turned off. Please turn on EPS to execute command\n"
         self.subsystems = default_subsystem_state.copy()
+        return "Subsystems returned to default state\n"
 
     def subsystem_on(self, subsystem_name):
         """

--- a/EPS/eps_subsystem.py
+++ b/EPS/eps_subsystem.py
@@ -95,7 +95,9 @@ class EPSSubsystem: #pylint:disable=too-few-public-methods disable=too-many-inst
             'ResetDevice': self.reset_device,
             'ResetSubsystems': self.reset_subsystems_state,
             'SubsystemOn': self.subsystem_on,
-            'SubsystemOff': self.subsystem_off
+            'SubsystemOff': self.subsystem_off,
+            'TurnOnEPS': self.turn_on_eps,
+            'TurnOffEPS': self.turn_off_eps
 
         }
 

--- a/EPS/eps_subsystem.py
+++ b/EPS/eps_subsystem.py
@@ -50,7 +50,9 @@ default_subsystem_state = {
     'DFGM': False,
     'GPS': False,
     'IRIS': False,
-    'UHF': False
+    'UHF': False,
+    'AntennaBurnWireGPIO': False,
+    'UHFBurnWireGPIO': False
 }
 
 class EPSSubsystem: #pylint:disable=too-few-public-methods disable=too-many-instance-attributes
@@ -81,7 +83,9 @@ class EPSSubsystem: #pylint:disable=too-few-public-methods disable=too-many-inst
             'DFGM': False,
             'GPS': False,
             'IRIS': False,
-            'UHF': False
+            'UHF': False,
+            'AntennaBurnWireGPIO': False,
+            'UHFBurnWireGPIO': False
         }
 
         self.eps_on = True

--- a/EPS/eps_subsystem.py
+++ b/EPS/eps_subsystem.py
@@ -44,6 +44,15 @@ default_eps_state = {
     'WatchdogResetTime': 24.0,   # in hours
 }
 
+default_subsystem_state = {
+    'ADCS': False,
+    'Deployables': False,
+    'DFGM': False,
+    'GPS': False,
+    'IRIS': False,
+    'UHF': False
+}
+
 class EPSSubsystem: #pylint:disable=too-few-public-methods disable=too-many-instance-attributes
     """Holds the state of the EPS subsystem.
 
@@ -66,14 +75,77 @@ class EPSSubsystem: #pylint:disable=too-few-public-methods disable=too-many-inst
         }
         self.updatable_parameters = ['WatchdogResetTime']
 
+        self.subsystems = {
+            'ADCS': False,
+            'Deployables': False,
+            'DFGM': False,
+            'GPS': False,
+            'IRIS': False,
+            'UHF': False
+        }
+
+        self.eps_on = True
+
         # Changing executable command tuples to dictionaries to point to fxns
         self.executable_commands = {
             'ResetDevice': self.reset_device,
+            'ResetSubsystems': self.reset_subsystems_state,
+            'SubsystemOn': self.subsystem_on,
+            'SubsystemOff': self.subsystem_off
+
         }
 
+    def turn_on_eps(self):
+        """Turn on the EPS subsystem"""
+        self.eps_on = True
+        return "EPS turned ON\n"
+    def turn_off_eps(self):
+        """Turn off the EPS subsystem"""
+        self.eps_on = False
+        return "EPS turned OFF\n"
     def reset_device(self):
-        """Reset the device to default state, which is defined at the top of this file. """
+        """Reset the device to default state, which is defined at the top of this file."""
+        if self.eps_on is False:
+            return "ERROR: EPS turned off. Please turn on EPS to execute command\n"
         self.set_state_dict(default_eps_state)
+    def reset_subsystems_state(self):
+        """Reset the subsystems to default state, which is defined at the top of this file."""
+        if self.eps_on is False:
+            return "ERROR: EPS turned off. Please turn on EPS to execute command\n"
+        self.subsystems = default_subsystem_state.copy()
+
+    def subsystem_on(self, subsystem_name):
+        """
+    Turn off the specified subsystem.
+
+    Args:
+        subsystem_name (str): The name of the subsystem to turn off.
+
+    Returns:
+        str: A message indicating the result of the operation.
+    """
+        if self.eps_on is False:
+            return "ERROR: EPS turned off. Please turn on EPS to execute command\n"
+        if subsystem_name in self.subsystems:
+            self.subsystems[subsystem_name] = True
+            return f"{subsystem_name} turned ON\n"
+        return f"ERROR: {subsystem_name} is not a valid subsystem\n"
+    def subsystem_off(self, subsystem_name):
+        """
+    Turn off the specified subsystem.
+
+    Args:
+        subsystem_name (str): The name of the subsystem to turn off.
+
+    Returns:
+        str: A message indicating the result of the operation.
+    """
+        if self.eps_on is False:
+            return "ERROR: EPS turned off. Please turn on EPS to execute command\n"
+        if subsystem_name in self.subsystems:
+            self.subsystems[subsystem_name] = False
+            return f"{subsystem_name} turned OFF\n"
+        return f"ERROR: {subsystem_name} is not a valid subsystem\n"
 
 
     def set_state_dict(self, new_state_dict):

--- a/EPS/eps_subsystem.py
+++ b/EPS/eps_subsystem.py
@@ -98,23 +98,23 @@ class EPSSubsystem: #pylint:disable=too-few-public-methods disable=too-many-inst
     def turn_on_eps(self):
         """Turn on the EPS subsystem"""
         self.eps_on = True
-        return "EPS turned ON\n"
+        print("EPS turned ON\n")
     def turn_off_eps(self):
         """Turn off the EPS subsystem"""
         self.eps_on = False
-        return "EPS turned OFF\n"
+        print("EPS turned OFF\n")
     def reset_device(self):
         """Reset the device to default state, which is defined at the top of this file."""
         if self.eps_on is False:
-            return "ERROR: EPS turned off. Please turn on EPS to execute command\n"
+            print("ERROR: EPS turned off. Please turn on EPS to execute command\n")
         self.set_state_dict(default_eps_state)
-        return "EPS returned to default state\n"
+        print("EPS printed to default state\n")
     def reset_subsystems_state(self):
         """Reset the subsystems to default state, which is defined at the top of this file."""
         if self.eps_on is False:
-            return "ERROR: EPS turned off. Please turn on EPS to execute command\n"
+            print("ERROR: EPS turned off. Please turn on EPS to execute command\n")
         self.subsystems = default_subsystem_state.copy()
-        return "Subsystems returned to default state\n"
+        print("Subsystems printed to default state\n")
 
     def subsystem_on(self, subsystem_name):
         """
@@ -123,15 +123,15 @@ class EPSSubsystem: #pylint:disable=too-few-public-methods disable=too-many-inst
     Args:
         subsystem_name (str): The name of the subsystem to turn off.
 
-    Returns:
+    prints:
         str: A message indicating the result of the operation.
     """
         if self.eps_on is False:
-            return "ERROR: EPS turned off. Please turn on EPS to execute command\n"
+            print("ERROR: EPS turned off. Please turn on EPS to execute command\n")
         if subsystem_name in self.subsystems:
             self.subsystems[subsystem_name] = True
-            return f"{subsystem_name} turned ON\n"
-        return f"ERROR: {subsystem_name} is not a valid subsystem\n"
+            print(f"{subsystem_name} turned ON\n")
+        print(f"ERROR: {subsystem_name} is not a valid subsystem\n")
     def subsystem_off(self, subsystem_name):
         """
     Turn off the specified subsystem.
@@ -139,15 +139,15 @@ class EPSSubsystem: #pylint:disable=too-few-public-methods disable=too-many-inst
     Args:
         subsystem_name (str): The name of the subsystem to turn off.
 
-    Returns:
+    prints:
         str: A message indicating the result of the operation.
     """
         if self.eps_on is False:
-            return "ERROR: EPS turned off. Please turn on EPS to execute command\n"
+            print("ERROR: EPS turned off. Please turn on EPS to execute command\n")
         if subsystem_name in self.subsystems:
             self.subsystems[subsystem_name] = False
-            return f"{subsystem_name} turned OFF\n"
-        return f"ERROR: {subsystem_name} is not a valid subsystem\n"
+            print(f"{subsystem_name} turned OFF\n")
+        print(f"ERROR: {subsystem_name} is not a valid subsystem\n")
 
 
     def set_state_dict(self, new_state_dict):

--- a/EPS/eps_subsystem.py
+++ b/EPS/eps_subsystem.py
@@ -1,42 +1,13 @@
-"""This python program represents a simulated version of the EPS payload for ExAlta3.
-
-For now the sub system communicates with strings over a TCP socket. The strings are parsed
-into a command type and associated data.
-
-Until we know more system specs I am assuming there are three types of commands that can be sent:
-    - Request - Request a paramater from the state dictionary
-    - Update  - Update a parameter in the state dictionary
-    - Execute - Execute a command (e.g. reset watchdog timer)
-
-# Example to update the WatchdogResetTime:
-     update:WatchdogResetTime:48.0
-
-# Example to request the Voltage:
-    request:Voltage
-
-# Example to execute a ResetWatchdogTimer command:
-    execute:ResetWatchdogTimer
-
-For now you can test your commands using netcat (nc) from the command line, and piping the command
-to the socket from a seperate text file.
-
-Usage: ESP_component.py non-default_port_num
-
-Copyright 2023 [Devin Headrick]. Licensed under the Apache License, Version 2.0
-"""
-
+"""This python program represents a simulated version of the EPS payload for ExAlta3."""
 import sys
-sys.path.append("../")
-from socket_stuff import create_socket_and_listen   # pylint: disable=C0413
-from command_handler import CommandHandler          # pylint: disable=C0413
-from command_factory import CommandFactory          # pylint: disable=C0413
-
+import socket
 
 DEFAULT_HOST = '127.0.0.1'
 DEFAULT_PORT = 1801
 COMMAND_DELIMITER = ':'
 
 default_eps_state = {
+    'EPSState' : 'ON',
     'Temperature': 32,           # in degrees C
     'Voltage': 5.24,             # in volts
     'Current': 1.32,             # in amps
@@ -55,148 +26,90 @@ default_subsystem_state = {
     'UHFBurnWireGPIO': False
 }
 
-class EPSSubsystem: #pylint:disable=too-few-public-methods disable=too-many-instance-attributes
-    """Holds the state of the EPS subsystem.
-
-    Tuples are defined that define the executable commands and updatable parameters.
-    Functions are defined which are called upon receipt of associated execute commands.
-    """
+class EPSSubsystem:
+    """Handles EPS subsystem state and command execution."""
 
     def __init__(self):
-        self.temperature = 32            # in degrees C
-        self.voltage = 5.24              # in volts
-        self.current = 1.32              # in amps
-        self.battery_state = 'Charging'
-        self.watchdog_reset_time = 24.0  # in hours
-        self.state = {
-            'Temperature': self.temperature,
-            'Voltage': self.voltage,
-            'Current': self.current,
-            'BatteryState': self.battery_state,
-            'WatchdogResetTime': self.watchdog_reset_time,
-        }
-        self.updatable_parameters = ['WatchdogResetTime']
-
-        self.subsystems = {
-            'ADCS': False,
-            'Deployables': False,
-            'DFGM': False,
-            'GPS': False,
-            'IRIS': False,
-            'UHF': False,
-            'AntennaBurnWireGPIO': False,
-            'UHFBurnWireGPIO': False
-        }
-
-        self.eps_on = True
-
-        # Changing executable command tuples to dictionaries to point to fxns
-        self.executable_commands = {
-            'ResetDevice': self.reset_device,
-            'ResetSubsystems': self.reset_subsystems_state,
-            'SubsystemOn': self.subsystem_on,
-            'SubsystemOff': self.subsystem_off,
-            'TurnOnEPS': self.turn_on_eps,
-            'TurnOffEPS': self.turn_off_eps
-
-        }
-
-    def turn_on_eps(self):
-        """Turn on the EPS subsystem"""
-        self.eps_on = True
-        print("EPS turned ON\n")
-    def turn_off_eps(self):
-        """Turn off the EPS subsystem"""
-        self.eps_on = False
-        print("EPS turned OFF\n")
-    def reset_device(self):
-        """Reset the device to default state, which is defined at the top of this file."""
-        if self.eps_on is False:
-            print("ERROR: EPS turned off. Please turn on EPS to execute command\n")
-        self.set_state_dict(default_eps_state)
-        print("EPS printed to default state\n")
-    def reset_subsystems_state(self):
-        """Reset the subsystems to default state, which is defined at the top of this file."""
-        if self.eps_on is False:
-            print("ERROR: EPS turned off. Please turn on EPS to execute command\n")
+        self.state = default_eps_state.copy()
         self.subsystems = default_subsystem_state.copy()
-        print("Subsystems printed to default state\n")
+        self.eps_on = True
 
-    def subsystem_on(self, subsystem_name):
-        """
-    Turn off the specified subsystem.
+    def handle_command(self, command):
+        """Handles commands"""
+        parts = command.strip().split(COMMAND_DELIMITER)
+        cmd_type = parts[0].lower()
 
-    Args:
-        subsystem_name (str): The name of the subsystem to turn off.
+        if cmd_type == "request" and len(parts) == 2:
+            return str(self.state.get(parts[1], "Unknown parameter"))
 
-    prints:
-        str: A message indicating the result of the operation.
-    """
+        if cmd_type == "update" and len(parts) == 3:
+            value = parts[2]
+            if value.replace('.', '', 1).isdigit():
+                value = float(value)
+                self.state[parts[1]] = value
+                return f"{parts[1]} updated to {self.state[parts[1]]}"
+            return "Unknown parameter"
+
+        if cmd_type == "execute" and len(parts) == 2:
+            return self.execute_command(parts[1])
+        if cmd_type == "execute" and len(parts) == 3:
+            return self.subsystem_commands(parts[1],parts[2])
+
+        return "Invalid command format"
+
+    def execute_command(self, command):
+        """Handles all executable commands"""
+        if command == "ResetDevice":
+            self.state = default_eps_state.copy()
+            return "Device reset to default state"
+        if command == "ResetSubsystems":
+            if self.eps_on is True:
+                self.subsystems = default_subsystem_state.copy()
+            return "EPS is off" if not self.eps_on else "Subsystems reset to default state"
+        if command == "TurnOnEPS":
+            self.eps_on = True
+            self.state["EPSState"] = "ON"
+            return "EPS turned ON"
+        if command == "TurnOffEPS":
+            self.eps_on = False
+            self.state["EPSState"] = "OFF"
+            return "EPS turned OFF"
+        return "Unknown command"
+    def subsystem_commands(self,command,subsystem):
+        "Handles on/off for other subsystems"
         if self.eps_on is False:
-            print("ERROR: EPS turned off. Please turn on EPS to execute command\n")
-        if subsystem_name in self.subsystems:
-            self.subsystems[subsystem_name] = True
-            print(f"{subsystem_name} turned ON\n")
-        print(f"ERROR: {subsystem_name} is not a valid subsystem\n")
-    def subsystem_off(self, subsystem_name):
-        """
-    Turn off the specified subsystem.
-
-    Args:
-        subsystem_name (str): The name of the subsystem to turn off.
-
-    prints:
-        str: A message indicating the result of the operation.
-    """
-        if self.eps_on is False:
-            print("ERROR: EPS turned off. Please turn on EPS to execute command\n")
-        if subsystem_name in self.subsystems:
-            self.subsystems[subsystem_name] = False
-            print(f"{subsystem_name} turned OFF\n")
-        print(f"ERROR: {subsystem_name} is not a valid subsystem\n")
-
-
-    def set_state_dict(self, new_state_dict):
-        """Set the state dictionary to the provided dictionary
-
-        This can be used to inject states into this subsystem for testing purposes.
-        """
-        try:
-            for key in self.state:
-                if key in new_state_dict:
-                    self.state[key] = new_state_dict[key]
-
-        except Exception as exeption: # pylint: disable=broad-except
-            print("Error setting state dictionary: " + str(exeption) +
-                  " \n Reset State to default values.")
-
+            return "EPS is off. Turn on EPS to execute subsystem commands"
+        if subsystem not in self.subsystems:
+            return "Invalid subsystem"
+        if command == "SubsystemOn":
+            self.subsystems[subsystem] = True
+            return f"{subsystem} turned ON"
+        if command == "SubsystemOff":
+            self.subsystems[subsystem] = False
+            return f"{subsystem} turned OFF"
+        if command == "SubsystemState":
+            return f"{subsystem} is ON" if self.subsystems[subsystem] else f"{subsystem} is OFF"
+        return "Unknown command"
 
 if __name__ == "__main__":
-    # If there is no arg, port is default otherwise use the arg
-    PORT = sys.argv[1] if len(sys.argv) > 1 else DEFAULT_PORT
+    PORT = int(sys.argv[1]) if len(sys.argv) > 1 else DEFAULT_PORT
 
     print(f"Starting EPS subsystem on port {PORT}")
 
-    # Concrete factory instance relies on subsystem class that contains associated state and fxns
-    command_factory = CommandFactory(EPSSubsystem())
+    eps = EPSSubsystem()
 
-    command_handler = CommandHandler(command_factory)
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as server_socket:
+        server_socket.bind((DEFAULT_HOST, PORT))
+        server_socket.listen()
+        print("EPS subsystem listening for connections...")
 
-    create_socket_and_listen(host=DEFAULT_HOST, port=PORT, command_handler_obj=command_handler)
-
-
-# pylint: disable=duplicate-code
-# no error
-__author__ = "Devin Headrick"
-__copyright__ = """
-    Copyright (C) 2023, [Devin Headrick]
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
-    http://www.apache.org/licenses/LICENSE-2.0
-
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License."""
+        while True:
+            conn, addr = server_socket.accept()
+            with conn:
+                print(f"Connected by {addr}")
+                data = conn.recv(1024).decode().strip()
+                if not data:
+                    break
+                response = eps.handle_command(data)
+                if response:
+                    conn.sendall((response+"\n").encode())


### PR DESCRIPTION
EPS ON/OFF Functionality:
- Added the ability to toggle the EPS state (ON/OFF).
- All executable commands return an error if attempted while the EPS is turned OFF.
- Note: This restriction currently applies only to executable commands. Update and request command types are unaffected.

Subsystem ON/OFF Functionality:
- Added the capability to toggle the state of other subsystems (e.g., ADCS, GPS, etc.) via EPS commands.
- These changes are visual-only and do not impact functionality outside this file.

Notes:
- The new functionality is isolated within the EPS subsystem and does not affect other files or components.