### PR TITLE
Ben/hotfix/change gps connection method

### DIFF
--- a/GPS/client.py
+++ b/GPS/client.py
@@ -20,30 +20,32 @@ Afterwards you may enter any of the valid commands from the client.
 import socket
 import sys
 
+DEFAULT_HOST = '127.0.0.1'
+DEFAULT_PORT = 1999
 PATH="/tmp/fifo_socket_gps_device"
 
-def connect() -> None:
+def connect(host, port) -> None:
     """
     Connects to server and allows for communication.
     """
-    with socket.socket(socket.AF_UNIX, socket.SOCK_SEQPACKET) as s:
-        s.connect(PATH)
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as client:
+        client.connect((host, port))
         print("Client connected.")
 
         while True:
             print("Possible commands: latlong, time, returnstate, ping, disconnect, terminate")
             commandstr=input(">>>")
             command = commandstr.encode('utf-8')
-            s.send(command)
+            client.send(command)
 
             if commandstr in ("terminate", "disconnect"):
                 print("Disconnecting")
                 break
-            data=s.recv(1024)
+            data=client.recv(1024)
             print(data.decode('utf-8'))
 
     print("Client disconnected.")
     sys.exit(0)
 
 if __name__ == "__main__":
-    connect()
+    connect(DEFAULT_HOST, DEFAULT_PORT)

--- a/GPS/client.py
+++ b/GPS/client.py
@@ -20,7 +20,7 @@ Afterwards you may enter any of the valid commands from the client.
 import socket
 import sys
 
-PATH="/tmp/server.sock"
+PATH="/tmp/fifo_socket_gps_device"
 
 def connect() -> None:
     """

--- a/GPS/client.py
+++ b/GPS/client.py
@@ -21,7 +21,7 @@ import socket
 import sys
 
 DEFAULT_HOST = '127.0.0.1'
-DEFAULT_PORT = 1999
+DEFAULT_PORT = 1810
 PATH="/tmp/fifo_socket_gps_device"
 
 def connect(host, port) -> None:

--- a/GPS/server.py
+++ b/GPS/server.py
@@ -19,21 +19,20 @@ import sys
 
 DEFAULT_HOST = '127.0.0.1'
 DEFAULT_PORT = 1999     # 1999 is a placeholder, change later
-PATH="/tmp/fifo_socket_gps_device"
+# PATH="/tmp/fifo_socket_gps_device"
 
-def open_server(port) -> None:
+def open_server(host, port) -> None:
     """
     Opens a listening server
     """
-    with socket.socket(socket.AF_UNIX, socket.SOCK_SEQPACKET) as s:
-        s.bind((DEFAULT_HOST, port))
-        print(f"Starting server on {PATH}\n")
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as server:
+        server.bind((host, port))
         while True:
-            print(f"Server started on {PATH}\nWaiting for Client.")
-            s.listen()
-            conn, addr = s.accept()
+            print(f"Server started on port {port}\nWaiting for client.")
+            server.listen()
+            conn, addr = server.accept()
             with conn:
-                print("Client connected.", addr)
+                print("Client connected. Addr:", addr)
                 while True:
                     command=conn.recv(1024) #buffsize 1024 bytes
                     command=command.decode("utf-8")
@@ -46,8 +45,6 @@ def open_server(port) -> None:
                         break
                     if command == "terminate":
                         print("Closing connection.")
-                        os.remove(PATH)
-                        print("Server socket file removed.")
                         sys.exit(0)
 
                     if command == "time":
@@ -62,10 +59,6 @@ def open_server(port) -> None:
                         command="invalid command"
                         data=b"[Server] Invalid command."
                     conn.send(data)
-        os.remove(PATH)
-        print("Server socket file removed.")
 
 if __name__ == "__main__":
-    if os.path.exists(PATH):
-        os.remove(PATH)
-    open_server(DEFAULT_PORT)
+    open_server(DEFAULT_HOST, DEFAULT_PORT)

--- a/GPS/server.py
+++ b/GPS/server.py
@@ -17,14 +17,16 @@ import os
 import socket
 import sys
 
+DEFAULT_HOST = '127.0.0.1'
+DEFAULT_PORT = 1999     # 1999 is a placeholder, change later
 PATH="/tmp/fifo_socket_gps_device"
 
-def open_server() -> None:
+def open_server(port) -> None:
     """
     Opens a listening server
     """
     with socket.socket(socket.AF_UNIX, socket.SOCK_SEQPACKET) as s:
-        s.bind(PATH)
+        s.bind((DEFAULT_HOST, port))
         print(f"Starting server on {PATH}\n")
         while True:
             print(f"Server started on {PATH}\nWaiting for Client.")
@@ -66,4 +68,4 @@ def open_server() -> None:
 if __name__ == "__main__":
     if os.path.exists(PATH):
         os.remove(PATH)
-    open_server()
+    open_server(DEFAULT_PORT)

--- a/GPS/server.py
+++ b/GPS/server.py
@@ -18,9 +18,7 @@ import socket
 import sys
 
 DEFAULT_HOST = '127.0.0.1'
-DEFAULT_PORT = 1999     # 1999 is a placeholder, change later
-# PATH="/tmp/fifo_socket_gps_device"
-
+DEFAULT_PORT = 1810
 def open_server(host, port) -> None:
     """
     Opens a listening server

--- a/GPS/server.py
+++ b/GPS/server.py
@@ -17,7 +17,7 @@ import os
 import socket
 import sys
 
-PATH="/tmp/server.sock"
+PATH="/tmp/fifo_socket_gps_device"
 
 def open_server() -> None:
     """

--- a/GPS/server.py
+++ b/GPS/server.py
@@ -13,7 +13,6 @@ At the moment, the three commands are:
 To test the server/client you must run both files in a UNIX environment.
 Afterwards you may enter any of the valid commands from the client.
 """
-import os
 import socket
 import sys
 


### PR DESCRIPTION
Changed the connection method of the GPS simulated subsystem server and client to TCP to keep it consistent with the rest of the other simulated subsystems and to get the python server to work with the GPS handler. Changes are only related to GPS simulated subsystem files.