### PR TITLE
fix: the subsystem should stay running even when a connection closes.

### DIFF
--- a/DFGM/dfgm_subsystem.py
+++ b/DFGM/dfgm_subsystem.py
@@ -239,6 +239,8 @@ if __name__ == "__main__":
                     simulator.start()
             except BrokenPipeError as e:
                 print(f"Client connection closed: {e}")
+            except ConnectionResetError as e:
+                print(f"Client connection reset: {e}")
 
 # The following is program metadata
 __author__ = "Daniel Sacro"


### PR DESCRIPTION
Prior to just now on my branch, our tests have a 50% chance of actually having the dfgm_subsystem.py running and giving simulated data. The alternative is having it sleep 1 second, which I don't like as much.