### PR TITLE
Implement encrypted AES-256-GCM uplink with sequential nonces

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -28,6 +28,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install pylint
+        pip install -r requirements.txt
     - name: Analysing the code with pylint
       run: |
         pylint $(git ls-files '*.py')

--- a/UHF/README.md
+++ b/UHF/README.md
@@ -2,19 +2,28 @@
 
 Simulates a UHF transceiver radio as a set of TCP servers for testing satellite flight software without physical hardware. An interactive fault injection CLI lets you corrupt, drop, delay, or duplicate packets on either side of the link at any time during a test.
 
+Uplink (ground station → satellite) is encrypted with AES-256-GCM using sequential nonces for replay protection. Downlink (satellite → ground station) is unchanged plaintext.
+
 ---
 
 ## Table of Contents
 
 1. [Quick Start](#quick-start)
 2. [Architecture](#architecture)
-3. [Launch Options](#launch-options)
-4. [Fault Injection CLI](#fault-injection-cli)
-5. [Testing Scenarios](#testing-scenarios)
+3. [Encrypted Uplink](#encrypted-uplink)
+4. [Launch Options](#launch-options)
+5. [Fault Injection CLI](#fault-injection-cli)
+6. [Testing Scenarios](#testing-scenarios)
 
 ---
 
 ## Quick Start
+
+Install Python dependencies from the repository root:
+
+```bash
+pip install -r requirements.txt
+```
 
 **Fully simulated — single machine, no hardware:**
 ```bash
@@ -36,6 +45,12 @@ Once running, the fault injection prompt appears immediately:
 uhf-fault>
 ```
 
+Use `generic_client.py` against the radio port (`1808`) to send encrypted operator uplink:
+
+```bash
+python3 generic_client.py 1808
+```
+
 ---
 
 ## Architecture
@@ -46,14 +61,16 @@ The simulator exposes three TCP servers. The ground station client connects to t
 Ground Station Client               Satellite / FSW Client
         │                                     │
         │ TCP :1808                           │ TCP :1805
+        │ (encrypt uplink)                    │ (plaintext downlink)
         ▼                                     ▼
  ┌──────────────┐    radio_buffer    ┌──────────────┐
  │ Radio Server │ ─────────────────► │  UART Server │
  │   (GS side)  │ ◄───────────────── │  (SAT side)  │
- └──────────────┘    uart_buffer     └──────────────┘
-                            │
-                     ┌──────┴──────┐
-                     │ FaultState  │ ◄── CLI thread arms faults here
+ └──────────────┘    uart_buffer     └──────┬───────┘
+                            │               │
+                     ┌──────┴──────┐  CommsHandler decrypts
+                     │ FaultState  │  uplink, rejects replays
+                     │             │ ◄── CLI thread arms faults here
                      └─────────────┘
 
  Beacon Server (:1809) — independently transmits call sign every 30s
@@ -66,6 +83,23 @@ Ground Station Client               Satellite / FSW Client
 | 1805 | UART Server | Satellite / FSW |
 | 1808 | Radio Server | Ground station |
 | 1809 | Beacon Server | Ground station |
+
+---
+
+## Encrypted Uplink
+
+Operator messages are encrypted before they leave the ground-station client. The UART server's `CommsHandler` parses the sequential nonce, decrypts with AES-256-GCM, and ignores frames that reuse a previous nonce. Downlink bytes are not encrypted or decrypted by this path.
+
+**Frame format:** `nonce (12 bytes, big-endian counter) || ciphertext || tag (16 bytes)`
+
+**Key storage:**
+
+| Source | Description |
+|--------|-------------|
+| `UHF_AES256_KEY` env var | Preferred. 64 hex characters (32 raw bytes). |
+| `UHF/keys/dev_aes256.key` | Development placeholder only. Replace for non-dev use. |
+
+This Python path mirrors the planned flight-software use of AES-256-GCM (`aes-gcm` / Aes256Gcm) with sequential nonces as a message counter.
 
 ---
 
@@ -154,6 +188,15 @@ Print command reference or shut down the simulator.
 
 ## Testing Scenarios
 
+### does encrypted uplink decrypt on the satellite side?
+Start `simulated_uhf.py`, connect a sat-side client to `:1805`, and send from `generic_client.py 1808`. The UART client should receive the original plaintext; the radio path carries ciphertext.
+
+### does the CommsHandler reject a replayed uplink?
+```
+uhf-fault> duplicate sat 2
+```
+The second copy of an encrypted uplink reuses the same nonce and is ignored by `CommsHandler` before it reaches the satellite client.
+
 ### does the satellite retry after a dropped command?
 ```
 uhf-fault> drop sat 1
@@ -166,7 +209,7 @@ Send a command from the GS. The satellite receives nothing. Observe whether the 
 ```
 uhf-fault> corrupt sat 8 0
 ```
-Corrupts the first byte of the next command sent to the satellite. The FSW should detect a bad checksum and reject it rather than acting on garbage data.
+Corrupts the first byte of the next command sent to the satellite. With encryption enabled this will typically fail AES-GCM authentication and be ignored by `CommsHandler` rather than forwarded as garbage.
 
 To target a specific field in your packet structure, calculate the bit offset of that field and use it as `m`. For example, to corrupt 4 bits starting at byte 2:
 ```
@@ -187,7 +230,7 @@ If the GS expects a reply within 2 seconds, this will cause it to time out. Veri
 ```
 uhf-fault> duplicate sat 2
 ```
-The satellite receives the next command twice. Verify the FSW doesn't execute it twice (e.g. no double-fire of an actuator, no double-increment of a counter).
+For encrypted uplink, the duplicate is dropped by nonce checking. For plaintext downlink / non-encrypted experiments, verify the FSW doesn't execute twice.
 
 ---
 

--- a/UHF/comms_handler.py
+++ b/UHF/comms_handler.py
@@ -1,0 +1,84 @@
+"""Communications handler for encrypted uplink frames.
+
+Parses the sequential AES-GCM nonce, decrypts authenticated ciphertext,
+and ignores frames that reuse a previous nonce (replay protection).
+Downlink traffic is not handled here and remains plaintext.
+
+Copyright 2026 [Samuel Olabode]. Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+from uplink_crypto import UplinkCryptoError, UplinkDecryptor
+
+
+class CommsHandler:
+    """Receive-side handler for encrypted operator uplink messages."""
+
+    def __init__(self, decryptor: UplinkDecryptor | None = None):
+        """Create a comms handler.
+
+        Args:
+            decryptor: Optional decryptor instance. A default decryptor
+                loaded from the key store is created when omitted.
+        """
+        self._decryptor = decryptor if decryptor is not None else UplinkDecryptor()
+        self._accepted = 0
+        self._ignored = 0
+
+    @property
+    def accepted_count(self) -> int:
+        """Number of uplink frames successfully decrypted."""
+        return self._accepted
+
+    @property
+    def ignored_count(self) -> int:
+        """Number of uplink frames dropped (replay, auth failure, etc.)."""
+        return self._ignored
+
+    @property
+    def last_nonce(self) -> int:
+        """Most recently accepted nonce counter."""
+        return self._decryptor.last_nonce
+
+    def handle_uplink(self, frame: bytes) -> bytes | None:
+        """Decrypt an encrypted uplink frame, or ignore it.
+
+        Args:
+            frame: Encrypted uplink bytes from the operator / ground station.
+
+        Returns:
+            bytes | None: Decrypted plaintext on success, or None when the
+                frame is ignored (previous nonce, auth failure, malformed).
+        """
+        try:
+            plaintext = self._decryptor.decrypt(frame)
+        except UplinkCryptoError as exc:
+            self._ignored += 1
+            print(f"[CommsHandler] ignoring uplink frame: {exc}")
+            return None
+
+        self._accepted += 1
+        print(
+            f"[CommsHandler] decrypted uplink nonce="
+            f"{self._decryptor.last_nonce} "
+            f"({len(plaintext)} plaintext bytes)"
+        )
+        return plaintext
+
+
+# pylint: disable=duplicate-code
+# no error
+__author__ = "Samuel Olabode"
+__copyright__ = """
+    Copyright (C) 2026, [Samuel Olabode]
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License."""

--- a/UHF/generic_client.py
+++ b/UHF/generic_client.py
@@ -1,9 +1,13 @@
 """ This program acts like a client to interact with the uhf tranceiver for testing purposes
 
-The port number for server is passed as a commmand line argument.
+The port number for server is passed as a command line argument.
 hostname is assumed to be local host.
 will listen and print any incoming messages to socket.
 can send messages back to server by simply writing a command in the terminal
+
+Uplink messages entered by the operator are encrypted with AES-256-GCM using
+a sequential nonce before they are sent. Downlink (received) messages are
+left unchanged and printed as plaintext.
 
 Copyright 2024 [Drake Boulianne]. Licensed under the Apache License, Version 2.0
 """
@@ -13,17 +17,25 @@ import socket
 import sys
 import threading
 
-def write_to_server(client, lock):
+from uplink_crypto import UplinkEncryptor
+
+
+def write_to_server(client, lock, encryptor):
     """
-    uses client and lock to communicate with server. messages are sent by reading 
-    standard input and the client sending all
+    uses client and lock to communicate with server. messages are sent by reading
+    standard input, encrypting them for uplink, and the client sending all
     """
     while True:
-        message = bytes(input(), "utf-8")
+        plaintext = bytes(input(), "utf-8")
         try:
+            message = encryptor.encrypt(plaintext)
             with lock:
                 client.sendall(message)
-                print(f"Sent {message}")
+                print(
+                    f"Sent encrypted uplink "
+                    f"(nonce={encryptor.next_counter - 1}, "
+                    f"{len(message)} bytes): {message.hex()}"
+                )
 
         except BrokenPipeError as e:
             print(f"Error sending data: {e}")
@@ -35,15 +47,15 @@ def write_to_server(client, lock):
             client.close()
             break
 
-BUFF_SIZE = 128
+BUFF_SIZE = 512
 
 def main():
 
-    """ main function that sets up generic client. The servers hostname will always be 
+    """ main function that sets up generic client. The servers hostname will always be
     the hosts name (as is in the simulated_uhf.py file) the desired port is given as a command
-    line arg. Client created will listen to messages indefinitely and be able to send messages to 
+    line arg. Client created will listen to messages indefinitely and be able to send messages to
     the server side client by way of the write thread.
-        
+
     Args:
         None
 
@@ -68,15 +80,22 @@ def main():
         print(f"Could not connect to hostname: {host} port: {port} - {e}")
         return -1
 
+    encryptor = UplinkEncryptor()
     client_lock = threading.Lock()
-    write_thread = threading.Thread(target=write_to_server, args=(client, client_lock))
+    write_thread = threading.Thread(
+        target=write_to_server, args=(client, client_lock, encryptor)
+    )
     write_thread.start()
 
     while True:
         try:
             msg = client.recv(BUFF_SIZE)
             if len(msg) > 0:
-                print(f"Received: {msg.decode('utf-8')}")
+                # Downlink remains plaintext / unchanged.
+                try:
+                    print(f"Received: {msg.decode('utf-8')}")
+                except UnicodeDecodeError:
+                    print(f"Received: {msg}")
 
         except BlockingIOError:
             continue
@@ -94,7 +113,7 @@ if __name__ == "__main__":
 
 # pylint: disable=duplicate-code
 # no error
-__author__ = "Drake Boulianne"
+__author__ = "Drake Boulianne, Samuel Olabode"
 __copyright__ = """
     Copyright (C) 2024, [Drake Boulianne]
     Licensed under the Apache License, Version 2.0 (the "License");

--- a/UHF/key_store.py
+++ b/UHF/key_store.py
@@ -1,0 +1,85 @@
+"""Load the AES-256-GCM key used for encrypted uplink.
+
+The key is expected from a secure location. For development a placeholder
+file under UHF/keys/ is used. Production deployments should set
+UHF_AES256_KEY to a 64-character hex string (32 raw bytes).
+
+Copyright 2026 [Samuel Olabode]. Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+KEY_SIZE = 32
+NONCE_SIZE = 12
+TAG_SIZE = 16
+
+# Overhead of nonce + GCM authentication tag on every encrypted uplink frame.
+ENCRYPTED_FRAME_OVERHEAD = NONCE_SIZE + TAG_SIZE
+
+_KEYS_DIR = Path(__file__).resolve().parent / "keys"
+_DEV_KEY_PATH = _KEYS_DIR / "dev_aes256.key"
+_ENV_VAR = "UHF_AES256_KEY"
+
+
+def _parse_hex_key(hex_key: str) -> bytes:
+    """Parse a hex-encoded AES-256 key and validate its length."""
+    cleaned = "".join(
+        line.split("#", 1)[0].strip()
+        for line in hex_key.splitlines()
+    )
+    cleaned = cleaned.replace(" ", "").replace("\n", "")
+    try:
+        key = bytes.fromhex(cleaned)
+    except ValueError as exc:
+        raise ValueError("AES key must be valid hexadecimal") from exc
+    if len(key) != KEY_SIZE:
+        raise ValueError(
+            f"AES-256 key must be {KEY_SIZE} bytes, got {len(key)}"
+        )
+    return key
+
+
+def load_aes_key(key_path: Path | None = None) -> bytes:
+    """Load the AES-256 key from the environment or a key file.
+
+    Precedence:
+      1. UHF_AES256_KEY environment variable (hex)
+      2. key_path argument, or the development placeholder file
+
+    Args:
+        key_path: Optional path to a hex-encoded key file.
+
+    Returns:
+        bytes: A 32-byte AES-256 key.
+    """
+    env_key = os.environ.get(_ENV_VAR)
+    if env_key:
+        return _parse_hex_key(env_key)
+
+    path = key_path if key_path is not None else _DEV_KEY_PATH
+    if not path.is_file():
+        raise FileNotFoundError(
+            f"AES key file not found at {path}. "
+            f"Set {_ENV_VAR} or provide a development key file."
+        )
+    return _parse_hex_key(path.read_text(encoding="utf-8"))
+
+
+# pylint: disable=duplicate-code
+# no error
+__author__ = "Samuel Olabode"
+__copyright__ = """
+    Copyright (C) 2026, [Samuel Olabode]
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License."""

--- a/UHF/keys/dev_aes256.key
+++ b/UHF/keys/dev_aes256.key
@@ -1,0 +1,4 @@
+# Development-only AES-256 key (hex-encoded, 32 bytes).
+# Replace with a securely provisioned key for non-development use.
+# Override at runtime with the UHF_AES256_KEY environment variable.
+0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef

--- a/UHF/simulated_uhf.py
+++ b/UHF/simulated_uhf.py
@@ -45,6 +45,9 @@ import threading
 import time
 import copy
 
+from comms_handler import CommsHandler
+from key_store import ENCRYPTED_FRAME_OVERHEAD
+
 UART_PORT = 1805
 RADIO_PORT = 1808
 BEACON_PORT = 1809
@@ -58,7 +61,8 @@ BEACON_CALL_SIGN = "VE6 LRN"
 BEACON_TX_CONTENTS = "beacon"
 BEACON_TX_MESSAGE = f"{BEACON_CALL_SIGN}{BEACON_TX_CONTENTS}"
 
-MAX_PAYLOAD_SIZE = 256
+# Room for plaintext payloads plus AES-GCM nonce/tag overhead on uplink.
+MAX_PAYLOAD_SIZE = 256 + ENCRYPTED_FRAME_OVERHEAD
 
 class FaultState:
     """
@@ -182,7 +186,8 @@ class RelayServer(threading.Thread):
     """
 
     def __init__(self, name, ipaddr, port, outbound_buffer,
-                 inbound_buffer, fault_state, fault_direction):
+                 inbound_buffer, fault_state, fault_direction,
+                 comms_handler=None):
         """ Creates a Relay Server"""
         super().__init__(daemon=True)
         self.name = name
@@ -192,6 +197,8 @@ class RelayServer(threading.Thread):
         self.inbound_buffer = inbound_buffer
         self.fault_state = fault_state
         self.fault_direction = fault_direction
+        # Optional uplink decryptor used only on the satellite-facing path.
+        self.comms_handler = comms_handler
 
     def run(self):
         """
@@ -244,6 +251,17 @@ class RelayServer(threading.Thread):
             try:
                 while True:
                     msg = self.inbound_buffer.get_nowait()
+                    # Decrypt encrypted operator uplink before delivery to the
+                    # satellite. Downlink (gs direction) is left unchanged.
+                    if self.comms_handler is not None:
+                        plaintext = self.comms_handler.handle_uplink(msg)
+                        if plaintext is None:
+                            print(
+                                f"[{self.name}] uplink ignored "
+                                f"(replay/auth failure)"
+                            )
+                            continue
+                        msg = plaintext
                     forward, msg, duplicate = self.fault_state.apply_faults(
                         self.fault_direction, msg)
                     if not forward:
@@ -481,9 +499,12 @@ def main():
     uart_buffer = queue.Queue()
     radio_buffer = queue.Queue()
     fault_state  = FaultState()
+    # Decrypts GS→sat uplink; radio/gs path keeps downlink plaintext.
+    comms_handler = CommsHandler()
 
     uart_server   = RelayServer("UHF Uart Server",  args.uart_ip,   UART_PORT,
-                                radio_buffer, uart_buffer,  fault_state, "sat")
+                                radio_buffer, uart_buffer,  fault_state, "sat",
+                                comms_handler=comms_handler)
     radio_server  = RelayServer("UHF Radio Server", args.radio_ip,  RADIO_PORT,
                                 uart_buffer,  radio_buffer, fault_state, "gs")
     beacon_server = BeaconServer("UHF Beacon Server", args.beacon_ip, BEACON_PORT,
@@ -496,6 +517,7 @@ def main():
     cli.start()
 
     print("Simulated UHF up. Ctrl+C to stop.")
+    print("Encrypted uplink enabled (AES-256-GCM); downlink unchanged.")
     try:
         while True:
             time.sleep(1)

--- a/UHF/simulated_uhf.py
+++ b/UHF/simulated_uhf.py
@@ -170,7 +170,7 @@ def _corrupt_bytes(data, count, offset):
     return bytes(ba)
 
 
-class RelayServer(threading.Thread):
+class RelayServer(threading.Thread):  # pylint: disable=too-many-instance-attributes
     """
     Server daemon bound to a given port, and IP address.
 

--- a/UHF/uplink_crypto.py
+++ b/UHF/uplink_crypto.py
@@ -1,0 +1,137 @@
+"""AES-256-GCM helpers for encrypted uplink frames.
+
+Mirrors the aes-gcm / Aes256Gcm approach planned for flight software:
+sequential nonces act as a message counter, and GCM authenticates the
+ciphertext so tampered frames fail decryption.
+
+Wire format:  nonce (12 bytes, big-endian counter) || ciphertext||tag
+
+Copyright 2026 [Samuel Olabode]. Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+from cryptography.exceptions import InvalidTag
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+from key_store import KEY_SIZE, NONCE_SIZE, load_aes_key
+
+
+class UplinkCryptoError(Exception):
+    """Raised when an uplink frame cannot be encrypted or decrypted."""
+
+
+class UplinkEncryptor:
+    """Encrypt operator uplink messages with sequential AES-GCM nonces."""
+
+    def __init__(self, key: bytes | None = None, start_counter: int = 1):
+        """Create an encryptor.
+
+        Args:
+            key: Optional 32-byte AES key. Loads from key store when omitted.
+            start_counter: First nonce counter value to use (default 1).
+        """
+        if start_counter < 1:
+            raise ValueError("start_counter must be >= 1")
+        self._key = key if key is not None else load_aes_key()
+        if len(self._key) != KEY_SIZE:
+            raise ValueError(f"AES-256 key must be {KEY_SIZE} bytes")
+        self._aesgcm = AESGCM(self._key)
+        self._counter = start_counter
+
+    @property
+    def next_counter(self) -> int:
+        """Return the counter that will be used for the next encrypt call."""
+        return self._counter
+
+    def encrypt(self, plaintext: bytes) -> bytes:
+        """Encrypt plaintext and return nonce || ciphertext||tag.
+
+        Args:
+            plaintext: Raw operator message bytes.
+
+        Returns:
+            bytes: Encrypted uplink frame including the sequential nonce.
+        """
+        if not isinstance(plaintext, (bytes, bytearray)):
+            raise TypeError("plaintext must be bytes")
+        nonce = self._counter.to_bytes(NONCE_SIZE, "big")
+        ciphertext = self._aesgcm.encrypt(nonce, bytes(plaintext), None)
+        self._counter += 1
+        return nonce + ciphertext
+
+
+class UplinkDecryptor:
+    """Decrypt uplink frames and enforce monotonic nonce counters."""
+
+    def __init__(self, key: bytes | None = None):
+        """Create a decryptor.
+
+        Args:
+            key: Optional 32-byte AES key. Loads from key store when omitted.
+        """
+        self._key = key if key is not None else load_aes_key()
+        if len(self._key) != KEY_SIZE:
+            raise ValueError(f"AES-256 key must be {KEY_SIZE} bytes")
+        self._aesgcm = AESGCM(self._key)
+        self._last_nonce = 0
+
+    @property
+    def last_nonce(self) -> int:
+        """Return the most recently accepted nonce counter."""
+        return self._last_nonce
+
+    def decrypt(self, frame: bytes) -> bytes:
+        """Parse the nonce, reject replays, and decrypt the ciphertext.
+
+        Args:
+            frame: Encrypted uplink frame (nonce || ciphertext||tag).
+
+        Returns:
+            bytes: Decrypted plaintext.
+
+        Raises:
+            UplinkCryptoError: If the frame is truncated, replayed, or
+                fails authentication.
+        """
+        if not isinstance(frame, (bytes, bytearray)):
+            raise TypeError("frame must be bytes")
+        if len(frame) <= NONCE_SIZE:
+            raise UplinkCryptoError("uplink frame too short")
+
+        nonce = bytes(frame[:NONCE_SIZE])
+        ciphertext = bytes(frame[NONCE_SIZE:])
+        counter = int.from_bytes(nonce, "big")
+
+        if counter <= self._last_nonce:
+            raise UplinkCryptoError(
+                f"rejected replayed or stale nonce {counter} "
+                f"(last accepted {self._last_nonce})"
+            )
+
+        try:
+            plaintext = self._aesgcm.decrypt(nonce, ciphertext, None)
+        except InvalidTag as exc:
+            raise UplinkCryptoError(
+                "AES-GCM authentication failed for uplink frame"
+            ) from exc
+
+        self._last_nonce = counter
+        return plaintext
+
+
+# pylint: disable=duplicate-code
+# no error
+__author__ = "Samuel Olabode"
+__copyright__ = """
+    Copyright (C) 2026, [Samuel Olabode]
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+cryptography>=41,<44


### PR DESCRIPTION
## Summary
- Encrypts operator uplink with AES-256-GCM and a sequential nonce (message counter) to block replays, matching the planned `aes-gcm` / Aes256Gcm approach from #83.
- Adds `CommsHandler` on the simulated UHF UART path to parse the nonce, decrypt authenticated frames, and ignore previous/reused nonces.
- Leaves downlink unchanged; stores the AES key via `UHF_AES256_KEY` or a development placeholder under `UHF/keys/`.

## Test plan
- [ ] `pip install -r requirements.txt`
- [ ] Start `python3 UHF/simulated_uhf.py`
- [ ] Connect a sat-side client to `:1805` and `python3 UHF/generic_client.py 1808`
- [ ] Confirm GS input arrives as plaintext on the UART client and that radio logs show ciphertext
- [ ] Arm `duplicate sat 2` and confirm the replayed uplink is ignored by `CommsHandler`
- [ ] Confirm downlink (UART → radio → GS client) remains plaintext
- [ ] Confirm pylint CI passes with the new cryptography dependency

Closes #83