### PR TITLE
Add simulated S-Band HSTXC I2C register interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,11 @@ Simulated subsystems for use with the simulated software architecture in Alberta
 ### Documentation 
 - Each command the subsystem is expected to receive should be included in a tuple.
 
+### Subsystems
+| Directory | Port | Notes |
+|-----------|------|-------|
+| `SBAND/` | 1812 | Simulated S-Band HSTXC I2C register interface (TCP) |
+
 &nbsp;
 
 Please see Contributing_README.md for expectations with contributing, such as branch naming conventions and branching etiquette 
-
-

--- a/SBAND/README.md
+++ b/SBAND/README.md
@@ -1,0 +1,70 @@
+# Simulated S-Band Transceiver
+
+TCP stand-in for the Ex-Alta 3 S-Band transmitter's I2C register interface ([issue #79](https://github.com/AlbertaSat/ex3_simulated_subsystems/issues/79)).
+
+The flight handler configures the HSTXC over I2C (device address `0x26`) using the register map from [AlbertaSat/ex2_sband_software](https://github.com/AlbertaSat/ex2_sband_software) (`sTransmitter.h`, HSTXC-01-00090). This simulator exposes that same register bank over TCP so the handler can read/write dummy data without hardware.
+
+RF transmit and SPI buffer fill are **out of scope** for now (per the issue).
+
+---
+
+## Quick start
+
+```bash
+# Terminal 1 — simulated I2C device
+python3 SBAND/sband_subsystem.py          # default 127.0.0.1:1812
+# or: python3 sband_subsystem.py 1812     # from inside SBAND/
+
+# Terminal 2 — handler-style scripted test
+python3 SBAND/sband_test_client.py
+
+# Or interact with netcat
+nc 127.0.0.1 1812
+```
+
+---
+
+## TCP protocol (I2C analogue)
+
+Commands are newline-terminated. Addresses/values accept decimal or `0x` hex.
+
+| Command | I2C analogue | Response |
+|---------|--------------|----------|
+| `read:<addr>` | `read_reg(addr)` → send `[addr]`, recv `[val]` | `OK:0xAA:0xVV` |
+| `write:<addr>:<value>` | `write_reg(addr, val)` → send `[addr, val]` | `OK:0xAA:0xVV` |
+| `reset` | write soft-reset register `0x05` | `OK:reset` |
+| `list` | dump readable registers | `OK:list` + lines |
+| `ping` / `help` / `quit` | — | status / usage / close |
+
+Access rules mirrored from the equipment handler:
+
+- Only control/encoder/PA power/frequency/soft-reset are writable
+- Soft-reset (`write:0x05:...` or `reset`) restores defaults
+- Encoder (`0x01`) may only be written while CONTROL mode is Configuration (`0x00` bits `[1:0] == 00`)
+
+---
+
+## Register map (HSTXC)
+
+| Addr | Name | Access | Notes |
+|------|------|--------|-------|
+| `0x00` | CONTROL | R/W | mode `[1:0]`, PA enable bit 7 |
+| `0x01` | ENCODER | R/W | rate/mod/filter/scrambler/bit order |
+| `0x03` | PAPOWER | R/W | 0–3 → 24/26/28/30 dBm |
+| `0x04` | FREQ | R/W | frequency offset byte |
+| `0x05` | SOFTRST | W | any write triggers soft reset |
+| `0x11` | FWVER | R | dummy `0x71` (7.1) |
+| `0x12` | STATUS | R | PA good / lock bits |
+| `0x13` | TXREADY | R | transmit ready |
+| `0x14`–`0x19` | buffer | R | count / underrun / overrun |
+| `0x1A`–`0x29` | housekeeping | R | power, temps, currents, voltages |
+
+---
+
+## Files
+
+| File | Role |
+|------|------|
+| `sband_registers.py` | HSTXC register map + in-memory bank |
+| `sband_subsystem.py` | TCP server (simulated I2C device) |
+| `sband_test_client.py` | Scripted S-Band handler test client |

--- a/SBAND/sband_registers.py
+++ b/SBAND/sband_registers.py
@@ -1,0 +1,225 @@
+"""HSTXC S-Band transmitter register map and in-memory register bank.
+
+Register addresses and access rules match AlbertaSat's S-Band equipment
+handler (HSTXC-01-00090 / sTransmitter.h in ex2_sband_software):
+I2C device address 0x26, 8-bit register accesses.
+
+Copyright (C) 2026 University of Alberta.
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+# I2C device address used by the flight S-Band handler.
+SBAND_I2C_ADDRESS = 0x26
+
+# Register Values (read-write)
+S_CONTROL_REG = 0x00
+S_ENCODER_REG = 0x01
+S_PAPOWER_REG = 0x03
+S_FREQ_REG = 0x04
+
+# Register Values (write-only)
+S_SOFTRST_REG = 0x05
+
+# Register Values (read-only)
+S_FWVER_REG = 0x11
+S_STATUS_REG = 0x12
+S_TXREADY_REG = 0x13
+S_BUFUND_REG_1 = 0x14
+S_BUFUND_REG_2 = 0x15
+S_BUFOVR_REG_1 = 0x16
+S_BUFOVR_REG_2 = 0x17
+S_BUFCNT_REG_1 = 0x18
+S_BUFCNT_REG_2 = 0x19
+S_OUTPWR_REG_1 = 0x1A
+S_OUTPWR_REG_2 = 0x1B
+S_PATEMP_REG_1 = 0x1C
+S_PATEMP_REG_2 = 0x1D
+S_TOPTEMP_REG_1 = 0x1E
+S_TOPTEMP_REG_2 = 0x1F
+S_BOTTEMP_REG_1 = 0x20
+S_BOTTEMP_REG_2 = 0x21
+S_CURRENT_REG_1 = 0x22
+S_CURRENT_REG_2 = 0x23
+S_VOLTAGE_REG_1 = 0x24
+S_VOLTAGE_REG_2 = 0x25
+S_PACURRENT_REG_1 = 0x26
+S_PACURRENT_REG_2 = 0x27
+S_PAVOLTAGE_REG_1 = 0x28
+S_PAVOLTAGE_REG_2 = 0x29
+
+S_LAST_REG = S_PAVOLTAGE_REG_2
+
+# Control / encoder bit helpers (mirrors sTransmitter.h)
+S_CONTROL_MODE_BITMASK = 0b11
+S_CONTROL_PA_BIT_INDEX = 7
+S_CONF_MODE = 0
+
+REGISTER_NAMES = {
+    S_CONTROL_REG: "CONTROL",
+    S_ENCODER_REG: "ENCODER",
+    S_PAPOWER_REG: "PAPOWER",
+    S_FREQ_REG: "FREQ",
+    S_SOFTRST_REG: "SOFTRST",
+    S_FWVER_REG: "FWVER",
+    S_STATUS_REG: "STATUS",
+    S_TXREADY_REG: "TXREADY",
+    S_BUFUND_REG_1: "BUFUND_1",
+    S_BUFUND_REG_2: "BUFUND_2",
+    S_BUFOVR_REG_1: "BUFOVR_1",
+    S_BUFOVR_REG_2: "BUFOVR_2",
+    S_BUFCNT_REG_1: "BUFCNT_1",
+    S_BUFCNT_REG_2: "BUFCNT_2",
+    S_OUTPWR_REG_1: "OUTPWR_1",
+    S_OUTPWR_REG_2: "OUTPWR_2",
+    S_PATEMP_REG_1: "PATEMP_1",
+    S_PATEMP_REG_2: "PATEMP_2",
+    S_TOPTEMP_REG_1: "TOPTEMP_1",
+    S_TOPTEMP_REG_2: "TOPTEMP_2",
+    S_BOTTEMP_REG_1: "BOTTEMP_1",
+    S_BOTTEMP_REG_2: "BOTTEMP_2",
+    S_CURRENT_REG_1: "CURRENT_1",
+    S_CURRENT_REG_2: "CURRENT_2",
+    S_VOLTAGE_REG_1: "VOLTAGE_1",
+    S_VOLTAGE_REG_2: "VOLTAGE_2",
+    S_PACURRENT_REG_1: "PACURRENT_1",
+    S_PACURRENT_REG_2: "PACURRENT_2",
+    S_PAVOLTAGE_REG_1: "PAVOLTAGE_1",
+    S_PAVOLTAGE_REG_2: "PAVOLTAGE_2",
+}
+
+READABLE_REGISTERS = frozenset(
+    addr for addr in REGISTER_NAMES if addr != S_SOFTRST_REG
+)
+WRITABLE_REGISTERS = frozenset(
+    {
+        S_CONTROL_REG,
+        S_ENCODER_REG,
+        S_PAPOWER_REG,
+        S_FREQ_REG,
+        S_SOFTRST_REG,
+    }
+)
+
+
+def default_register_values() -> dict[int, int]:
+    """Return power-on / soft-reset dummy register values.
+
+    Telemetry-style read-only registers are filled with fixed dummy data so
+    a handler can exercise housekeeping reads without real RF hardware.
+    """
+    values = {addr: 0x00 for addr in REGISTER_NAMES}
+
+    # Firmware 7.1 encoded as (major << 4) | minor
+    values[S_FWVER_REG] = 0x71
+    # PA power good + frequency lock
+    values[S_STATUS_REG] = 0x03
+    # Transmit ready (buffer not full)
+    values[S_TXREADY_REG] = 0x01
+    # Amateur-band mid frequency offset: (2425 - 2400) * 2 = 50
+    values[S_FREQ_REG] = 0x32
+    # Dummy scaled housekeeping raw bytes (not converted here)
+    values[S_OUTPWR_REG_1] = 0x05
+    values[S_OUTPWR_REG_2] = 0xA0
+    values[S_PATEMP_REG_1] = 0x04
+    values[S_PATEMP_REG_2] = 0x20
+    values[S_TOPTEMP_REG_1] = 0x01
+    values[S_TOPTEMP_REG_2] = 0x00
+    values[S_BOTTEMP_REG_1] = 0x01
+    values[S_BOTTEMP_REG_2] = 0x80
+    values[S_CURRENT_REG_1] = 0x00
+    values[S_CURRENT_REG_2] = 0x64
+    values[S_VOLTAGE_REG_1] = 0x07
+    values[S_VOLTAGE_REG_2] = 0x08
+    values[S_PACURRENT_REG_1] = 0x00
+    values[S_PACURRENT_REG_2] = 0x30
+    values[S_PAVOLTAGE_REG_1] = 0x04
+    values[S_PAVOLTAGE_REG_2] = 0xF0
+    return values
+
+
+class SBandRegisterBank:
+    """In-memory S-Band I2C register bank with HSTXC access rules."""
+
+    def __init__(self):
+        """Initialize registers to default dummy values."""
+        self._registers = default_register_values()
+
+    def reset(self) -> None:
+        """Restore all registers to power-on defaults (soft reset)."""
+        self._registers = default_register_values()
+
+    def read(self, address: int) -> int:
+        """Read one 8-bit register, matching I2C read_reg behaviour.
+
+        Args:
+            address: Register address from the HSTXC map.
+
+        Returns:
+            int: Register value in range 0-255.
+
+        Raises:
+            KeyError: If the address is unknown or write-only.
+        """
+        if address not in READABLE_REGISTERS:
+            raise KeyError(f"register 0x{address:02X} is not readable")
+        return self._registers[address]
+
+    def write(self, address: int, value: int) -> None:
+        """Write one 8-bit register, matching I2C write_reg behaviour.
+
+        Encoder writes are only accepted while CONTROL mode is Configuration,
+        matching STX_setEncoder in the equipment handler. Writing SOFTRST
+        triggers a full soft reset of the register bank.
+
+        Args:
+            address: Register address from the HSTXC map.
+            value: Byte to store (masked to 8 bits).
+
+        Raises:
+            KeyError: If the address is not writable.
+            ValueError: If encoder write is attempted outside config mode.
+        """
+        if address not in WRITABLE_REGISTERS:
+            raise KeyError(f"register 0x{address:02X} is not writable")
+
+        value &= 0xFF
+
+        if address == S_SOFTRST_REG:
+            self.reset()
+            return
+
+        if address == S_ENCODER_REG:
+            mode = self._registers[S_CONTROL_REG] & S_CONTROL_MODE_BITMASK
+            if mode != S_CONF_MODE:
+                raise ValueError(
+                    "ENCODER may only be written while CONTROL mode is Configuration"
+                )
+
+        self._registers[address] = value
+
+    def dump(self) -> dict[int, int]:
+        """Return a copy of all known register values."""
+        return dict(self._registers)
+
+    def name(self, address: int) -> str:
+        """Return the symbolic name for a register address."""
+        return REGISTER_NAMES.get(address, f"UNKNOWN_0x{address:02X}")
+
+
+# pylint: disable=duplicate-code
+# no error
+__author__ = "AlbertaSat"
+__copyright__ = """
+    Copyright (C) 2026, University of Alberta.
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License."""

--- a/SBAND/sband_subsystem.py
+++ b/SBAND/sband_subsystem.py
@@ -1,0 +1,220 @@
+"""TCP server simulating the S-Band transmitter I2C register interface.
+
+The flight S-Band handler talks to the HSTXC over I2C (device 0x26) using:
+  write_reg(addr, val) -> send [addr, val]
+  read_reg(addr)       -> send [addr], receive [val]
+
+This simulator exposes the same register bank over TCP so a handler client
+can configure and read dummy register data without hardware. RF transmit /
+SPI buffer fill is intentionally out of scope for now (see issue #79).
+
+Protocol (newline-terminated, colon-delimited):
+  read:<addr>           -> OK:<addr>:<value>   or ERROR:...
+  write:<addr>:<value>  -> OK:<addr>:<value>   or ERROR:...
+  reset                 -> OK:reset
+  list                  -> multi-line OK dump of readable registers
+  ping                  -> OK:pong
+  help                  -> OK:command list
+  quit / exit           -> closes the client connection
+
+Addresses and values accept decimal or 0x-prefixed hex.
+
+Copyright (C) 2026 University of Alberta.
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import socket
+import sys
+
+from sband_registers import SBAND_I2C_ADDRESS, SBandRegisterBank
+
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 1812
+COMMAND_DELIMITER = ":"
+
+SUPPORTED_COMMANDS = (
+    "read",
+    "write",
+    "reset",
+    "list",
+    "ping",
+    "help",
+    "quit",
+    "exit",
+)
+
+
+def parse_byte(token: str) -> int:
+    """Parse a decimal or hex byte token into an int 0-255."""
+    value = int(token, 0)
+    if value < 0 or value > 0xFF:
+        raise ValueError(f"byte out of range: {token}")
+    return value
+
+
+class SBandSubsystem:
+    """Simulated S-Band I2C register device served over TCP."""
+
+    def __init__(self):
+        """Create the subsystem with a fresh register bank."""
+        self.registers = SBandRegisterBank()
+        self._handlers = {
+            "quit": self._cmd_quit,
+            "exit": self._cmd_quit,
+            "ping": self._cmd_ping,
+            "help": self._cmd_help,
+            "reset": self._cmd_reset,
+            "list": self._cmd_list,
+            "read": self._cmd_read,
+            "write": self._cmd_write,
+        }
+
+    def reset_registers(self) -> None:
+        """Public helper to restore default dummy register values."""
+        self.registers.reset()
+
+    def handle_command(self, command: str) -> str:
+        """Parse and execute one newline-stripped command string.
+
+        Args:
+            command: Raw command from the S-Band handler TCP client.
+
+        Returns:
+            str: Response body; the server appends ``\\n`` when sending.
+        """
+        parts = command.strip().split(COMMAND_DELIMITER)
+        if not parts or not parts[0]:
+            return "ERROR: empty command"
+
+        handler = self._handlers.get(parts[0].lower())
+        if handler is None:
+            return "ERROR: unknown command (try help)"
+        return handler(parts)
+
+    @staticmethod
+    def _cmd_quit(_parts):
+        return "OK:bye"
+
+    @staticmethod
+    def _cmd_ping(_parts):
+        return "OK:pong"
+
+    @staticmethod
+    def _cmd_help(_parts):
+        return (
+            "OK:commands "
+            + ",".join(SUPPORTED_COMMANDS)
+            + f" i2c_addr=0x{SBAND_I2C_ADDRESS:02X}"
+        )
+
+    def _cmd_reset(self, _parts):
+        self.reset_registers()
+        return "OK:reset"
+
+    def _cmd_list(self, _parts):
+        lines = ["OK:list"]
+        for addr, value in sorted(self.registers.dump().items()):
+            name = self.registers.name(addr)
+            lines.append(f"0x{addr:02X}:{name}:0x{value:02X}")
+        return "\n".join(lines)
+
+    def _cmd_read(self, parts):
+        if len(parts) != 2:
+            return "ERROR: usage read:<addr>"
+        try:
+            addr = parse_byte(parts[1])
+            value = self.registers.read(addr)
+        except (ValueError, KeyError) as exc:
+            return f"ERROR: {exc}"
+        return f"OK:0x{addr:02X}:0x{value:02X}"
+
+    def _cmd_write(self, parts):
+        if len(parts) != 3:
+            return "ERROR: usage write:<addr>:<value>"
+        try:
+            addr = parse_byte(parts[1])
+            value = parse_byte(parts[2])
+            self.registers.write(addr, value)
+            return f"OK:0x{addr:02X}:0x{value:02X}"
+        except (ValueError, KeyError) as exc:
+            return f"ERROR: {exc}"
+
+
+def serve(host: str = DEFAULT_HOST, port: int = DEFAULT_PORT) -> None:
+    """Bind a TCP server and serve S-Band I2C register commands."""
+    subsystem = SBandSubsystem()
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as server_socket:
+        server_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        server_socket.bind((host, port))
+        server_socket.listen()
+        print(
+            f"S-Band simulated I2C interface listening on {host}:{port} "
+            f"(device 0x{SBAND_I2C_ADDRESS:02X})",
+            flush=True,
+        )
+
+        while True:
+            try:
+                conn, addr = server_socket.accept()
+            except KeyboardInterrupt:
+                print("Keyboard interrupt. Closing S-Band server.", flush=True)
+                break
+
+            with conn:
+                print(f"S-Band handler connected: {addr}", flush=True)
+                while True:
+                    try:
+                        data = conn.recv(1024)
+                    except ConnectionResetError:
+                        print("Client reset connection.", flush=True)
+                        break
+
+                    if not data:
+                        print("S-Band handler disconnected.", flush=True)
+                        break
+
+                    command = data.decode(errors="replace").strip()
+                    if not command:
+                        continue
+
+                    print(f"RAW command: {command}", flush=True)
+                    response = subsystem.handle_command(command)
+                    conn.sendall((response + "\n").encode())
+
+                    if command.lower() in ("quit", "exit"):
+                        break
+
+
+def main() -> int:
+    """CLI entry point."""
+    port = int(sys.argv[1]) if len(sys.argv) > 1 else DEFAULT_PORT
+    try:
+        serve(DEFAULT_HOST, port)
+    except OSError as exc:
+        print(f"Failed to start S-Band server: {exc}", flush=True)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+
+
+# pylint: disable=duplicate-code
+# no error
+__author__ = "AlbertaSat"
+__copyright__ = """
+    Copyright (C) 2026, University of Alberta.
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License."""

--- a/SBAND/sband_test_client.py
+++ b/SBAND/sband_test_client.py
@@ -1,0 +1,116 @@
+"""Test client that exercises the simulated S-Band I2C TCP interface.
+
+Acts as a stand-in for the S-Band handler: connects to the simulated
+subsystem, writes configuration registers, reads them back, and samples
+dummy housekeeping / status registers.
+
+Usage:
+  Terminal 1: python3 sband_subsystem.py
+  Terminal 2: python3 sband_test_client.py [host] [port]
+
+Copyright (C) 2026 University of Alberta.
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import socket
+import sys
+
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 1812
+
+
+def exchange(sock: socket.socket, command: str) -> str:
+    """Send one command and return the response text."""
+    sock.sendall((command + "\n").encode())
+    data = sock.recv(4096)
+    return data.decode(errors="replace").strip()
+
+
+def run_handler_tests(host: str, port: int) -> int:
+    """Run a scripted handler-style read/write sequence against the simulator."""
+    print(f"Connecting to simulated S-Band at {host}:{port}")
+    with socket.create_connection((host, port), timeout=5) as sock:
+        checks = [
+            ("ping", "OK:pong"),
+            ("read:0x00", "OK:0x00:0x00"),
+            ("write:0x00:0x01", "OK:0x00:0x01"),  # mode = Synchronization
+            ("read:0x00", "OK:0x00:0x01"),
+            # Encoder write should fail outside Configuration mode
+            ("write:0x01:0x04", None),
+            ("write:0x00:0x00", "OK:0x00:0x00"),  # back to Configuration
+            ("write:0x01:0x04", "OK:0x01:0x04"),
+            ("read:0x01", "OK:0x01:0x04"),
+            ("write:0x03:0x02", "OK:0x03:0x02"),  # PA power code
+            ("write:0x04:0x32", "OK:0x04:0x32"),  # frequency offset
+            ("read:0x11", "OK:0x11:0x71"),  # firmware 7.1
+            ("read:0x12", "OK:0x12:0x03"),  # status
+            ("read:0x13", "OK:0x13:0x01"),  # tx ready
+            ("reset", "OK:reset"),
+            ("read:0x00", "OK:0x00:0x00"),
+        ]
+
+        failures = 0
+        for command, expected in checks:
+            response = exchange(sock, command)
+            print(f"> {command}")
+            print(f"< {response}")
+
+            if expected is None:
+                if not response.startswith("ERROR:"):
+                    print(f"FAIL: expected ERROR for {command}, got {response}")
+                    failures += 1
+                continue
+
+            if response != expected:
+                print(f"FAIL: expected {expected}")
+                failures += 1
+
+        list_response = exchange(sock, "list")
+        print("> list")
+        print(f"< {list_response.splitlines()[0]} ...")
+        if not list_response.startswith("OK:list"):
+            print("FAIL: list did not return OK:list")
+            failures += 1
+
+        exchange(sock, "quit")
+
+    if failures:
+        print(f"S-Band handler simulation tests FAILED ({failures})")
+        return 1
+
+    print("S-Band handler simulation tests PASSED")
+    return 0
+
+
+def main() -> int:
+    """CLI entry point."""
+    host = sys.argv[1] if len(sys.argv) > 1 else DEFAULT_HOST
+    port = int(sys.argv[2]) if len(sys.argv) > 2 else DEFAULT_PORT
+    try:
+        return run_handler_tests(host, port)
+    except OSError as exc:
+        print(f"Could not talk to simulated S-Band: {exc}")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+
+
+# pylint: disable=duplicate-code
+# no error
+__author__ = "AlbertaSat"
+__copyright__ = """
+    Copyright (C) 2026, University of Alberta.
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License."""


### PR DESCRIPTION
## Summary
- Adds a TCP-backed S-Band simulator (`SBAND/`) that exposes the HSTXC I2C register map (device `0x26`) used by AlbertaSat’s S-Band equipment handler.
- Supports I2C-style `read` / `write` / soft-reset against dummy registers, including Configuration-mode-only encoder writes.
- Includes a scripted handler test client and docs; RF transmit / SPI buffer fill left out of scope per #79.

## Test plan
- [ ] `python3 SBAND/sband_subsystem.py`
- [ ] `python3 SBAND/sband_test_client.py` → expects `PASSED`
- [ ] Manual `nc 127.0.0.1 1812` checks for `read:0x11`, `write:0x00:0x01`, `reset`
- [ ] Confirm encoder write fails outside Configuration mode
- [ ] Confirm pylint passes on new `SBAND/*.py` files

Closes #79